### PR TITLE
feat: replace dead Yandex Sitesearch with self-hosted Orama search

### DIFF
--- a/blocks/common/page/__js/page__js.bemhtml.js
+++ b/blocks/common/page/__js/page__js.bemhtml.js
@@ -1,0 +1,7 @@
+// Mark every <script> emitted via { elem: 'js', url } as type="module".
+// All client JS in this project is shipped as ES modules with code-splitting
+// (see scripts/vite-client.config.mjs); the chunks/ directory next to
+// client.js is loaded by the browser via dynamic import only when needed.
+block('page').elem('js')(
+    addAttrs()({ type: 'module' })
+);

--- a/blocks/common/root/root.bemtree.js
+++ b/blocks/common/root/root.bemtree.js
@@ -40,7 +40,7 @@ block('root').replace()(function() {
         ],
         favicon: data.root + '/favicon.ico',
         scripts: [
-            { elem: 'js', url: data.root + '/' + siteBundle + '.' + data.lang + '.min.js?' + staticVersion }
+            { elem: 'js', url: data.root + '/_client/client.js?' + staticVersion }
         ]
     };
 });

--- a/blocks/common/search/search.bemhtml.js
+++ b/blocks/common/search/search.bemhtml.js
@@ -1,7 +1,11 @@
 block('search')(
     addJs()(true),
     elem('submit')(
-        tag()('button'),
-        addAttrs()({ type: 'submit' })
+        tag()('span'),
+        addAttrs()({ role: 'button', 'aria-label': 'search' })
+    ),
+    elem('results')(
+        tag()('div'),
+        addAttrs()({ role: 'listbox' })
     )
 );

--- a/blocks/common/search/search.bemtree.js
+++ b/blocks/common/search/search.bemtree.js
@@ -4,28 +4,17 @@ block('search').content()(function() {
 
     return [
         {
-            block: 'form',
-            mix: [
-                { block: 'search', elem: 'form', elemMods: { site: siteMod } }
-            ],
-            action: 'https://yandex.' + (lang === 'ru' ? 'ru' : 'com') + '/sitesearch',
+            block: 'search',
+            elem: 'form',
+            elemMods: { site: siteMod },
             content: [
                 {
                     block: 'input',
                     mods: { type: 'search' },
-                    name: 'text',
+                    name: 'q',
                     autocomplete: false,
                     // TODO i18n
-                    placeholder: lang === 'ru' ? 'Искать' : 'Search'
-                },
-                {
-                    tag: 'input', attrs: { type: 'hidden', name: 'reqenc' }
-                },
-                {
-                    tag: 'input', attrs: { type: 'hidden', name: 'searchid', value: '1944806' }
-                },
-                {
-                    tag: 'input', attrs: { type: 'hidden', name: 'l10n', value: lang }
+                    placeholder: lang === 'ru' ? 'Поиск по сайту' : 'Search the docs'
                 },
                 {
                     block: 'search',
@@ -34,7 +23,8 @@ block('search').content()(function() {
                         block: 'search-icon',
                         mix: { block: 'search', elem: 'submit-icon' }
                     }
-                }
+                },
+                { block: 'search', elem: 'results' }
             ]
         }
     ];

--- a/blocks/common/search/search.css
+++ b/blocks/common/search/search.css
@@ -121,6 +121,116 @@
     color: rgba(255, 255, 255, 0.6);
 }
 
+.search__results
+{
+    position: absolute;
+    z-index: 10;
+    top: 70px;
+    right: 0;
+    left: 0;
+
+    overflow-y: auto;
+
+    max-height: 70vh;
+
+    color: #222;
+    background: #fff;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+}
+
+.search__results[hidden]
+{
+    display: none;
+}
+
+.search__hit
+{
+    display: block;
+
+    padding: 12px 20px;
+
+    text-decoration: none;
+
+    color: inherit;
+
+    border-bottom: 1px solid #eee;
+}
+
+.search__hit:last-child
+{
+    border-bottom: 0;
+}
+
+.search__hit:hover,
+.search__hit_active
+{
+    background: #f5f5f5;
+}
+
+.search__hit-title
+{
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 1.3;
+
+    display: block;
+}
+
+.search__hit-subtitle
+{
+    font-size: 13px;
+    line-height: 1.3;
+
+    display: block;
+
+    margin-top: 2px;
+
+    color: #777;
+}
+
+.search__hit-excerpt
+{
+    font-size: 13px;
+    line-height: 1.4;
+
+    display: block;
+    display: -webkit-box;
+    overflow: hidden;
+
+    margin-top: 4px;
+
+    text-overflow: ellipsis;
+
+    color: #555;
+
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.search__mark
+{
+    padding: 0 1px;
+
+    color: inherit;
+    border-radius: 2px;
+    background: rgba(255, 204, 0, 0.5);
+}
+
+.search__hit_active .search__mark,
+.search__hit:hover .search__mark
+{
+    background: rgba(255, 204, 0, 0.85);
+}
+
+.search__hint
+{
+    font-size: 14px;
+
+    padding: 14px 20px;
+
+    color: #666;
+}
+
 @media (max-width: 800px)
 {
     .search
@@ -196,5 +306,15 @@
 
         width: 19px;
         height: 19px;
+    }
+
+    .search__results
+    {
+        position: static;
+
+        max-height: none;
+        margin: 0 10px;
+
+        box-shadow: none;
     }
 }

--- a/blocks/common/search/search.deps.js
+++ b/blocks/common/search/search.deps.js
@@ -1,6 +1,5 @@
 ({
     shouldDeps: [
-        'form',
         'events',
         'header',
         'search-icon',
@@ -12,9 +11,8 @@
             block: 'input',
             mods: {
                 type: 'search'
-                // 'has-clear': true
             }
         },
-        { elems: ['submit', 'open', 'close'] }
+        { elems: ['submit', 'open', 'close', 'results'] }
     ]
 })

--- a/blocks/common/search/search.js
+++ b/blocks/common/search/search.js
@@ -1,3 +1,286 @@
 import bemDom from 'bem:i-bem-dom';
+import Input from 'bem:input';
+import KeyCodes from 'bem:keyboard__codes';
 
-export default bemDom.declBlock('search', {});
+const MIN_QUERY = 2;
+const DEBOUNCE_MS = 100;
+const RESULT_LIMIT = 8;
+
+const SEARCH_SCHEMA = {
+    url: 'string',
+    title: 'string',
+    subtitle: 'string',
+    site: 'string',
+    tags: 'string[]',
+    body: 'string'
+};
+
+let dbPromise = null;
+
+function pageLang() {
+    const code = (document.documentElement.lang || 'en').slice(0, 2).toLowerCase();
+    return code === 'ru' ? 'ru' : 'en';
+}
+
+function indexUrl(lang) {
+    const base = document.documentElement.dataset.langRoot || `/${lang}`;
+    return `${base}/_search/index.json`;
+}
+
+async function loadDb() {
+    const lang = pageLang();
+    const [orama, stemmerMod, res] = await Promise.all([
+        import('@orama/orama'),
+        lang === 'ru'
+            ? import('@orama/stemmers/russian')
+            : import('@orama/stemmers/english'),
+        fetch(indexUrl(lang))
+    ]);
+    if (!res.ok) throw new Error(`search index ${res.status}`);
+    const raw = await res.json();
+
+    const db = orama.create({
+        schema: SEARCH_SCHEMA,
+        components: {
+            tokenizer: {
+                language: lang === 'ru' ? 'russian' : 'english',
+                stemmer: stemmerMod.stemmer
+            }
+        }
+    });
+    await orama.load(db, raw);
+    return db;
+}
+
+function getDb() {
+    if (!dbPromise) {
+        dbPromise = loadDb().catch(err => {
+            dbPromise = null;
+            throw err;
+        });
+    }
+    return dbPromise;
+}
+
+function escapeHtml(str) {
+    return String(str || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function escapeRegex(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const HL_PREFIX_LEN = 4;
+const EXCERPT_CTX = 80;
+
+// Build a regex that matches each query token (or its 4-letter prefix for
+// short tokens we lose to stemming) plus the rest of the word. Two regexes:
+// `find` — single match for excerpt anchoring; `all` — global, for highlight.
+function buildHighlighter(term) {
+    const tokens = [...new Set(
+        String(term || '').toLowerCase().split(/\s+/).filter(t => t.length >= 2)
+    )];
+    if (!tokens.length) return null;
+
+    const prefixes = [...new Set(tokens.map(t =>
+        t.length <= HL_PREFIX_LEN ? t : t.slice(0, HL_PREFIX_LEN)
+    ))].sort((a, b) => b.length - a.length);
+
+    const pattern = prefixes.map(escapeRegex).join('|');
+    return {
+        find: new RegExp(`(?:${pattern})\\p{L}*`, 'iu'),
+        all: new RegExp(`(?:${pattern})\\p{L}*`, 'giu')
+    };
+}
+
+function highlight(text, hl) {
+    if (!text) return '';
+    if (!hl) return escapeHtml(text);
+
+    hl.all.lastIndex = 0;
+    let out = '';
+    let last = 0;
+    let m;
+    while ((m = hl.all.exec(text)) !== null) {
+        if (m.index > last) out += escapeHtml(text.slice(last, m.index));
+        out += '<mark class="search__mark">' + escapeHtml(m[0]) + '</mark>';
+        last = m.index + m[0].length;
+        if (m[0].length === 0) hl.all.lastIndex++;
+    }
+    if (last < text.length) out += escapeHtml(text.slice(last));
+    return out;
+}
+
+function makeExcerpt(text, hl) {
+    if (!text || !hl) return null;
+    hl.find.lastIndex = 0;
+    const m = hl.find.exec(text);
+    if (!m) return null;
+    const start = Math.max(0, m.index - EXCERPT_CTX);
+    const end = Math.min(text.length, m.index + m[0].length + EXCERPT_CTX);
+    let snippet = text.slice(start, end);
+    if (start > 0) snippet = '…' + snippet;
+    if (end < text.length) snippet = snippet + '…';
+    return snippet;
+}
+
+function renderItem(hit, hl) {
+    const doc = hit.document;
+    const titleHtml = highlight(doc.title || '', hl);
+    const subtitleHtml = doc.subtitle
+        ? `<span class="search__hit-subtitle">${highlight(doc.subtitle, hl)}</span>`
+        : '';
+
+    let excerptHtml = '';
+    if (hl && doc.body) {
+        const inTitle = hl.find.test(doc.title || '');
+        hl.find.lastIndex = 0;
+        const inSubtitle = doc.subtitle ? hl.find.test(doc.subtitle) : false;
+        hl.find.lastIndex = 0;
+        if (!inTitle && !inSubtitle) {
+            const snippet = makeExcerpt(doc.body, hl);
+            if (snippet) {
+                excerptHtml = `<span class="search__hit-excerpt">${highlight(snippet, hl)}</span>`;
+            }
+        }
+    }
+
+    return `<a class="search__hit" role="option" href="${escapeHtml(doc.url)}">
+        <span class="search__hit-title">${titleHtml}</span>
+        ${subtitleHtml}
+        ${excerptHtml}
+    </a>`;
+}
+
+export default bemDom.declBlock('search', {
+    onSetMod: {
+        js: {
+            inited: function() {
+                this._input = this.findChildBlock(Input);
+                this._results = this.findChildElem('results');
+                this._resultsDom = this._results.domElem[0];
+                this._activeIndex = -1;
+                this._lastTerm = '';
+
+                this._events(this._input).on('change', this._onInputChange, this);
+                this._domEvents(this._input).on('keydown', this._onInputKey, this);
+                this._domEvents(this._results).on('mousedown', '.search__hit', this._onHitMouseDown, this);
+            }
+        },
+        loading: {
+            'true': function() { this._renderState('loading'); },
+            'error': function() { this._renderState('error'); },
+            '': function() { /* clear handled per-render */ }
+        }
+    },
+
+    _onInputChange: function() {
+        const term = this._input.getVal().trim();
+        if (term === this._lastTerm) return;
+        this._lastTerm = term;
+
+        clearTimeout(this._debounce);
+        if (term.length < MIN_QUERY) {
+            this._renderHits([]);
+            return;
+        }
+        this._debounce = setTimeout(() => this._search(term).catch(err => {
+            console.error('search:', err);
+            this.setMod('loading', 'error');
+        }), DEBOUNCE_MS);
+    },
+
+    _search: async function(term) {
+        this.setMod('loading', true);
+        const [{ search }, db] = await Promise.all([
+            import('@orama/orama'),
+            getDb()
+        ]);
+        // Term may have changed while we were loading
+        if (this._input.getVal().trim() !== term) return;
+
+        const result = await search(db, {
+            term,
+            properties: ['title', 'subtitle', 'body'],
+            boost: { title: 4, subtitle: 2, body: 1 },
+            limit: RESULT_LIMIT,
+            tolerance: 1
+        });
+
+        this.delMod('loading');
+        this._renderHits(result.hits || [], buildHighlighter(term));
+    },
+
+    _renderState: function(state) {
+        const lang = pageLang();
+        const messages = {
+            loading: { ru: 'Поиск…', en: 'Searching…' },
+            error: { ru: 'Не удалось загрузить индекс', en: 'Failed to load search index' }
+        };
+        const msg = messages[state]?.[lang] || '';
+        this._resultsDom.innerHTML = msg ? `<div class="search__hint">${escapeHtml(msg)}</div>` : '';
+        this._showResults(Boolean(msg));
+    },
+
+    _renderHits: function(hits, hl) {
+        this._activeIndex = -1;
+        if (!hits.length) {
+            const term = this._input.getVal().trim();
+            if (term.length >= MIN_QUERY) {
+                const lang = pageLang();
+                const msg = lang === 'ru' ? 'Ничего не найдено' : 'No results';
+                this._resultsDom.innerHTML = `<div class="search__hint">${escapeHtml(msg)}</div>`;
+                this._showResults(true);
+            } else {
+                this._showResults(false);
+            }
+            return;
+        }
+        this._resultsDom.innerHTML = hits.map(h => renderItem(h, hl)).join('');
+        this._showResults(true);
+    },
+
+    _showResults: function(show) {
+        if (show) {
+            this._resultsDom.removeAttribute('hidden');
+            this.setMod('has-results', true);
+        } else {
+            this._resultsDom.setAttribute('hidden', '');
+            this.delMod('has-results');
+            this._resultsDom.innerHTML = '';
+        }
+    },
+
+    _onInputKey: function(e) {
+        const items = this._resultsDom.querySelectorAll('.search__hit');
+        if (!items.length) return;
+
+        if (e.keyCode === KeyCodes.DOWN) {
+            e.preventDefault();
+            this._activeIndex = (this._activeIndex + 1) % items.length;
+            this._highlight(items);
+        } else if (e.keyCode === KeyCodes.UP) {
+            e.preventDefault();
+            this._activeIndex = (this._activeIndex - 1 + items.length) % items.length;
+            this._highlight(items);
+        } else if (e.keyCode === KeyCodes.ENTER && this._activeIndex >= 0) {
+            e.preventDefault();
+            window.location.href = items[this._activeIndex].getAttribute('href');
+        }
+    },
+
+    _highlight: function(items) {
+        for (let i = 0; i < items.length; i++) {
+            items[i].classList.toggle('search__hit_active', i === this._activeIndex);
+        }
+    },
+
+    _onHitMouseDown: function() {
+        // Default click → href works fine; mousedown handler kept as a hook
+        // for future analytics or to prevent input-blur cancelling navigation.
+    }
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",
+    "@orama/orama": "^3.1.18",
+    "@orama/stemmers": "^3.1.18",
     "autoprefixer": "^10.4.0",
     "bem-components": "^6.0.1",
     "bem-config": "^3.2.3",

--- a/scripts/bem-build.mjs
+++ b/scripts/bem-build.mjs
@@ -431,11 +431,9 @@ export async function buildBundle(bundle, langs, rootDir) {
             );
         }
 
-        // Client JS — copy the pre-built Vite bundle (same for all bundles/langs)
-        const clientJs = path.join(rootDir, '.build-client', 'client.js');
-        if (fs.existsSync(clientJs)) {
-            fs.copyFileSync(clientJs, path.join(bundleDir, `${bundle}.${lang}.js`));
-        }
+        // Client JS is built once into .build-client/ and shipped per-language
+        // as output/bem.info/<lang>/_client/ — see scripts/build.mjs
+        // copyClientToOutput(). It is no longer duplicated per bundle.
     }
 
     console.log(`  ✓ ${bundle}`);

--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -1,0 +1,119 @@
+/**
+ * Build per-language Orama search indexes from the gorshochek model.
+ *
+ * Reads `<cacheDir>/data.json` produced by `lib/data-builder.cjs`, pulls the
+ * pre-rendered HTML from `page.contentFile`, strips tags, and writes the
+ * serialized Orama index to `<outputDir>/_search/index.json`.
+ *
+ * The runtime calls `load()` on a fresh DB created with the correct stemmer,
+ * which keeps tokenization symmetric with indexing. We deliberately avoid
+ * @orama/plugin-data-persistence — its `restore` builds a stub DB without a
+ * tokenizer, so query tokens never match indexed ones.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { create, insertMultiple, save } from '@orama/orama';
+import { stemmer as stemmerEn } from '@orama/stemmers/english';
+import { stemmer as stemmerRu } from '@orama/stemmers/russian';
+
+const TOKENIZER_LANG = { en: 'english', ru: 'russian' };
+const STEMMERS = { en: stemmerEn, ru: stemmerRu };
+
+export const SEARCH_SCHEMA = {
+    url: 'string',
+    title: 'string',
+    subtitle: 'string',
+    site: 'string',
+    tags: 'string[]',
+    body: 'string'
+};
+
+function pickLang(value, lang) {
+    if (value == null) return '';
+    if (typeof value === 'string') return value;
+    return value[lang] ?? '';
+}
+
+function stripHtml(html) {
+    return html
+        .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+        .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function isIndexable(page) {
+    if (!page || !page.url) return false;
+    if (page.published === false) return false;
+    if (page.type === 'redirect') return false;
+    return Boolean(page.contentFile);
+}
+
+function buildRecord(page, lang) {
+    let body = '';
+    try {
+        const html = fs.readFileSync(page.contentFile, 'utf8');
+        body = stripHtml(html);
+    } catch {
+        return null;
+    }
+    if (!body) return null;
+    return {
+        id: page.url,
+        url: page.url,
+        title: pickLang(page.title, lang),
+        subtitle: pickLang(page.subtitle, lang),
+        site: page.site || '',
+        tags: Array.isArray(page.tags) ? page.tags : [],
+        body
+    };
+}
+
+export async function buildSearchIndex({ lang, cacheDir, outputDir }) {
+    const dataPath = path.join(cacheDir, 'data.json');
+    if (!fs.existsSync(dataPath)) {
+        console.warn(`Search: ${dataPath} not found, skipping ${lang}`);
+        return;
+    }
+
+    const pages = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+    const records = pages
+        .filter(isIndexable)
+        .map(p => buildRecord(p, lang))
+        .filter(Boolean);
+
+    const db = create({
+        schema: SEARCH_SCHEMA,
+        components: {
+            tokenizer: { language: TOKENIZER_LANG[lang], stemmer: STEMMERS[lang] }
+        }
+    });
+
+    await insertMultiple(db, records);
+
+    const json = JSON.stringify(await save(db));
+    const outFile = path.join(outputDir, '_search', 'index.json');
+    fs.mkdirSync(path.dirname(outFile), { recursive: true });
+    fs.writeFileSync(outFile, json);
+
+    const sizeKB = (Buffer.byteLength(json, 'utf8') / 1024).toFixed(1);
+    console.log(`Search: indexed ${records.length} ${lang}-pages → ${outFile} (${sizeKB} KB)`);
+}
+
+export async function buildAllSearchIndexes({ languages, cacheDirs, outputDirs }) {
+    for (const lang of languages) {
+        await buildSearchIndex({
+            lang,
+            cacheDir: cacheDirs[lang],
+            outputDir: outputDirs[lang]
+        });
+    }
+}

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -18,6 +18,7 @@ import { fileURLToPath } from 'node:url';
 import { build as viteBuild } from 'vite';
 import { transform as cssMinify } from 'lightningcss';
 import { buildAllBundles, collectFiles, copyCSSAssets, resolveDeps } from './bem-build.mjs';
+import { buildAllSearchIndexes } from './build-search-index.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -162,46 +163,40 @@ async function bemBuild() {
 }
 
 // ---------------------------------------------------------------------------
-// Minification (Vite/Rolldown for JS, lightningcss for CSS)
+// CSS minification (lightningcss). Client JS is already minified by Vite
+// when YENV=production, see scripts/vite-client.config.mjs.
 // ---------------------------------------------------------------------------
 
 async function minifyBundles() {
-    console.log('Minifying bundles...');
+    console.log('Minifying bundle CSS...');
     const bundles = fs.readdirSync(BUNDLES_DIR);
-    const tasks = [];
 
     for (const bundle of bundles) {
         const bundleDir = path.join(BUNDLES_DIR, bundle);
-
-        // Minify CSS via lightningcss
         const cssFile = path.join(bundleDir, `${bundle}.css`);
         if (fs.existsSync(cssFile)) {
             const code = fs.readFileSync(cssFile);
             const result = cssMinify({ filename: cssFile, code, minify: IS_PROD });
             fs.writeFileSync(path.join(bundleDir, `${bundle}.min.css`), result.code);
         }
-
-        // Minify JS per language via Vite/Rolldown
-        for (const lang of LANGUAGES) {
-            const jsFile = path.join(bundleDir, `${bundle}.${lang}.js`);
-            if (fs.existsSync(jsFile)) {
-                tasks.push(viteBuild({
-                    configFile: false,
-                    logLevel: 'warn',
-                    build: {
-                        write: true,
-                        minify: IS_PROD,
-                        emptyOutDir: false,
-                        lib: { entry: jsFile, formats: ['es'], fileName: `${bundle}.${lang}.min` },
-                        outDir: bundleDir,
-                    },
-                }));
-            }
-        }
     }
 
-    await Promise.all(tasks);
     console.log('Minification complete.');
+}
+
+// ---------------------------------------------------------------------------
+// Copy the shared client.js bundle (entry + lazy chunks) into each language
+// root as `_client/`. The script tag in root.bemtree references this path.
+// ---------------------------------------------------------------------------
+
+function copyClientToOutput() {
+    const src = path.join(ROOT, '.build-client');
+    if (!fs.existsSync(src)) return;
+    for (const lang of LANGUAGES) {
+        const dest = path.join(outputDirs[lang], '_client');
+        fs.rmSync(dest, { recursive: true, force: true });
+        copyDir(src, dest);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -483,10 +478,11 @@ async function fullBuild() {
     // Phase 2: Minify
     await minifyBundles();
 
-    // Phase 3: HTML + copy (parallel)
+    // Phase 3: HTML + copy + search index (parallel)
     await Promise.all([
         buildHTML(),
-        (copyBundlesToOutput(), copySitemaps(), Promise.resolve()),
+        (copyBundlesToOutput(), copySitemaps(), copyClientToOutput(), Promise.resolve()),
+        buildAllSearchIndexes({ languages: LANGUAGES, cacheDirs, outputDirs })
     ]);
 
     // Phase 3.5: Post-process HTML to make URLs relative
@@ -509,10 +505,11 @@ async function watchMode() {
 
     const { watch } = await import('node:fs');
 
-    // Watch content/ → rebuild data
+    // Watch content/ → rebuild data + search index
     fs.watch(path.join(ROOT, 'content'), { recursive: true }, debounce(async () => {
         console.log('\nContent changed, rebuilding data...');
         await buildData();
+        await buildAllSearchIndexes({ languages: LANGUAGES, cacheDirs, outputDirs });
     }, 500));
 
     // Watch blocks/ → rebuild BEM + minify + copy
@@ -521,6 +518,7 @@ async function watchMode() {
         await bemBuild();
         await minifyBundles();
         copyBundlesToOutput();
+        copyClientToOutput();
     }, 500));
 }
 
@@ -546,6 +544,9 @@ try {
         case 'compile':
             await bemBuild();
             await minifyBundles();
+            break;
+        case 'search-index':
+            await buildAllSearchIndexes({ languages: LANGUAGES, cacheDirs, outputDirs });
             break;
         case 'watch':
             await watchMode();

--- a/scripts/vite-client.config.mjs
+++ b/scripts/vite-client.config.mjs
@@ -1,8 +1,15 @@
 /**
- * Vite config for building client-side JS bundle.
+ * Vite config for the client-side JS bundle.
  *
- * Uses vite-plugin-bem-levels to resolve bem: imports across
- * bem-core blocks and project blocks.
+ * Builds an ES module entry (`client.js`) plus content-hashed chunks under
+ * `chunks/` for dynamic imports. The entire output dir is later copied as
+ * `output/bem.info/<lang>/_client/`, so the entry is loaded with
+ * `<script type="module" src="…/_client/client.js">` and the browser pulls
+ * chunks lazily from `…/_client/chunks/<name>-<hash>.js`.
+ *
+ * vite-plugin-bem-levels resolves `bem:` imports across bem-core and project
+ * blocks; everything else (npm packages, dynamic imports) goes through the
+ * normal Vite/Rollup pipeline.
  */
 
 import { defineConfig } from 'vite';
@@ -10,6 +17,7 @@ import { resolve } from 'node:path';
 import bemLevels from '../node_modules/bem-core/build/plugins/vite-plugin-bem-levels.js';
 
 const rootDir = resolve(import.meta.dirname, '..');
+const isProd = process.env.YENV === 'production';
 
 export default defineConfig({
     root: rootDir,
@@ -21,28 +29,28 @@ export default defineConfig({
                 desktop: [
                     'node_modules/bem-core/common.blocks',
                     'node_modules/bem-core/desktop.blocks',
-                    'blocks/common',
-                ],
+                    'blocks/common'
+                ]
             },
-            rootDir,
-        }),
+            rootDir
+        })
     ],
 
     build: {
-        lib: {
-            entry: resolve(import.meta.dirname, 'client-entry.mjs'),
-            name: 'bemInfo',
-            formats: ['iife'],
-            fileName: () => 'client.js',
-        },
         outDir: resolve(rootDir, '.build-client'),
         emptyOutDir: true,
         sourcemap: false,
-        minify: false,
+        minify: isProd,
+        target: 'es2020',
+        modulePreload: false,
         rollupOptions: {
+            input: resolve(import.meta.dirname, 'client-entry.mjs'),
             output: {
-                // IIFE — no externals, everything bundled including jQuery
-            },
-        },
-    },
+                format: 'es',
+                entryFileNames: 'client.js',
+                chunkFileNames: 'chunks/[name]-[hash].js',
+                assetFileNames: 'assets/[name]-[hash][extname]'
+            }
+        }
+    }
 });


### PR DESCRIPTION
## Summary

- Полностью убирает поломанный Яндекс.Sitesearch (`yandex.{ru,com}/sitesearch`, searchid 1944806) — сервис закрыт Яндексом в декабре 2022, эндпоинт сейчас редиректит на yandex.ru и игнорирует `l10n`. Это и есть корень #339 (русский UI поиска на en.bem.info при российском IP).
- Поиск теперь self-hosted на [Orama](https://github.com/oramasearch/orama): индексы строятся при сборке из gorshochek-кеша, кладутся в `output/bem.info/{lang}/_search/index.json`, клиент лениво подгружает индекс того языка, что у страницы.
- Заодно client-бандл переведён на нативные ES-modules с code-splitting — Orama теперь грузится отдельным чанком только при первом фокусе в поиск.

## Changes

**Search (новое)**
- `scripts/build-search-index.mjs`: индексер. Читает `data.json` от gorshochek, по `page.contentFile` достаёт готовый HTML, чистит теги, строит Orama-индекс с RU/EN-стеммером, сохраняет через нативный `save()`. Не использует `@orama/plugin-data-persistence` — его `restore()` теряет токенайзер, симметрия search↔index ломается.
- Интеграция в `scripts/build.mjs`: Phase 3 fullBuild параллельно с HTML, watch-режим, отдельный таргет `node scripts/build.mjs search-index`.
- `blocks/common/search/{search.bemtree,bemhtml,deps,js,css}`: input + dropdown результатов вместо Яндекс-form. Lazy-import Orama + стеммера, debounce, prefix-tolerant подсветка совпадений в title/subtitle, excerpt из body когда match только там, ↑/↓/Enter навигация. XSS-safe: каждый сегмент эскейпится отдельно.
- Подсветка через `<mark>` стилизована полупрозрачным жёлтым, при hover/keyboard-фокусе — насыщеннее.

**Client bundle migration to ES modules + code-splitting** (необходимо чтобы Orama была lazy)
- `scripts/vite-client.config.mjs`: выход из lib-режима, `format: 'es'` + `chunkFileNames: 'chunks/[name]-[hash].js'`. Минификация по `YENV=production`.
- `blocks/common/page/__js/page__js.bemhtml.js` (новый override): `addAttrs()({ type: 'module' })` для всех `<script>` через `{ elem: 'js', url }`. Inline-метрика рендерится напрямую тегом и не задета.
- `scripts/build.mjs`: новая `copyClientToOutput()` копирует `.build-client/*` в `output/bem.info/{lang}/_client/`. `minifyBundles()` сведена к CSS-only — JS уже минифицирован Vite, второй пакеджинг через Vite ломал чанки.
- `scripts/bem-build.mjs`: убрано дублирование `client.js` per-bundle/lang (было 26 копий одного файла).
- `blocks/common/root/root.bemtree.js`: URL скрипта → `/_client/client.js?<v>`.

## Production bundle sizes

| | Raw | Gzip |
|---|---|---|
| **Before** (IIFE, всё в одном) | 450 KB | 102 KB |
| **After** initial `client.js` | 112 KB | 39 KB |
| `chunks/browser-*.js` (Orama, lazy) | 79 KB | 25 KB |
| `chunks/ru-*.js` (русский стеммер) | 6.9 KB | 1.83 KB |
| `chunks/en-*.js` (английский стеммер) | 2.2 KB | 0.87 KB |

Initial JS −60% по gzip, Orama+стеммер пользователь скачивает только если открывает поиск.

## Test plan

- [x] `YENV=production npx vite build --config scripts/vite-client.config.mjs` — clean, разбивает на 4 файла как выше.
- [x] `YENV=production node scripts/build.mjs compile` — все 13 бандлов компилятся, в bundle-папках больше нет JS-копий, `page__js`-override в скомпилированных `*.bemhtml.cjs`.
- [x] Sample-рендер `BEMHTML.apply({...})` подтвердил `<script src="/_client/client.js?abc" type="module">`.
- [x] Smoke-тест индексера на моковых данных: `именами → именованию` (русский стеммер), `naming/namings → Naming` (английский стеммер), `bem` находит во всех вхождениях.
- [x] Unit-тест подсветки: prefix-tolerant matching работает для русского/английского, XSS-кейс с `<script>` в тексте экранируется корректно.
- [ ] Полный `npm run build` с GitHub TOKEN на CI.
- [ ] Pages-deploy и проверка на реальной странице.

Closes #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)