### PR TITLE
fix(search): prefix result URLs with language

### DIFF
--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -62,6 +62,16 @@ function isIndexable(page) {
     return true;
 }
 
+function langUrl(url, lang) {
+    // gorshochek's `page.url` is language-agnostic ("/methodology/...");
+    // on the live site every page lives under "/<lang>/..." instead, so we
+    // must prefix the index with the language so result links navigate to
+    // the correct page (and stay within the same language as the viewer).
+    if (!url) return url;
+    if (url === '/') return `/${lang}/`;
+    return url.startsWith('/') ? `/${lang}${url}` : url;
+}
+
 function buildRecord(page, lang, stats, cacheDir) {
     const title = pickLang(page.title, lang);
     const subtitle = pickLang(page.subtitle, lang);
@@ -94,9 +104,10 @@ function buildRecord(page, lang, stats, cacheDir) {
         stats.noContentFile++;
     }
 
+    const url = langUrl(page.url, lang);
     return {
-        id: page.url,
-        url: page.url,
+        id: url,
+        url,
         title,
         subtitle,
         site: page.site || '',


### PR DESCRIPTION
## Summary

Регрессия после #380: клик по результату саджеста ведёт на `https://bem.info/technologies/classic/i-bem/interaction/` (404) вместо `https://bem.info/ru/technologies/classic/i-bem/interaction/`.

## Cause

gorshochek хранит `page.url` без языкового префикса (`/methodology/quick-start/`). На проде же каждая страница живёт под `/<lang>/...` (а `relativizeUrls` в `scripts/build.mjs` именно на этом и стоит). Я записывал `page.url` в индекс как есть, поэтому каждый href приводил на несуществующий путь без префикса.

## Fix

Префикс применяется на этапе сборки индекса: `id` и `url` каждой записи становятся `/<lang>` + `page.url`. Индексы и так per-language, поэтому `en`-индекс получает `/en/...` ссылки, `ru` — `/ru/...`. Посетитель остаётся в том языке, в котором читает.

## Verified

```
[en] modifier  → /en/tutorials/classic/i-bem/modifiers/
[ru] именами   → /ru/toolbox/bemhint/css-naming/
[ru] i-bem     → /ru/technologies/classic/bem-xjst/7/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)