### PR TITLE
fix(search): focus input when the panel opens

### DIFF
--- a/blocks/common/search/search.js
+++ b/blocks/common/search/search.js
@@ -188,6 +188,15 @@ export default bemDom.declBlock('search', {
             'true': function() { this._renderState('loading'); },
             'error': function() { this._renderState('error'); },
             '': function() { /* clear handled per-render */ }
+        },
+        opened: {
+            'true': function() {
+                // Whoever opens the panel (header__toggle, our submit click,
+                // …) leaves focus to us. Defer past the click so the
+                // bubbling pointerup doesn't immediately blur the input.
+                if (!this._inputDom) return;
+                setTimeout(() => this._inputDom.focus(), 0);
+            }
         }
     },
 


### PR DESCRIPTION
Клик по лупе (которую на десктопе перехватывает невидимый `header__toggle`) раскрывал панель, но фокус не переводился в input — приходилось кликать второй раз. `header.js` пытается фокусить через `this.input.setMod('focused')` в обработчике `opened.true`, но forwarded `setMod` не всегда надёжно дотягивается до DOM input (таймминг bem-init, focus до того как панель видна и т. п.).

Вешаем focus прямо на `search.opened = true` — сработает кто бы ни выставил мод (header-toggle, наш submit-click, в будущем — keyboard-шорткат). `setTimeout(0)` уводит call за bubbling pointerup, иначе тот же клик блюрнул бы input.

## Verified

End-to-end через Playwright (bem.info/ru с интерсептом `_client/`):
- click `.header__toggle` → `document.activeElement === input[name="q"]` ✅
- `keyboard.type('именами')` без дополнительного клика — value лежит в input, top hit «CSS именование»

🤖 Generated with [Claude Code](https://claude.com/claude-code)