### PR TITLE
fix(search): skip pages with no real content from the index

### DIFF
--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -68,6 +68,13 @@ function isIndexable(page) {
     // for any common query and crowds out the actual article. Already
     // reachable via /methodology/.
     if (page.type === 'articles') return false;
+    // Only index pages that actually have something to display:
+    //  - anything with a contentFile (markdown was loaded for it)
+    //  - promo landing pages (rendered from a custom block)
+    // Many lib pages exist in the model without a markdown source — they
+    // render as blank on the live site. Indexing them by title-only would
+    // surface dead-end results in suggest.
+    if (!page.contentFile && page.type !== 'promo') return false;
     return true;
 }
 


### PR DESCRIPTION
## Symptom

User searches «mod» on /ru/ — top 3 hits подписаны одинаково «modal» и ведут на пустые страницы:

- https://bem.info/ru/libraries/classic/bem-components/6.0.0/desktop/modal/
- https://bem.info/ru/libraries/classic/bem-components/6.0.0/touch-pad/modal/
- https://bem.info/ru/libraries/classic/bem-components/6.0.0/touch-phone/modal/

Все три рендерятся blank.

## Cause

В `gorshochek`-модели много страниц без `contentFile` — для них markdown-source просто не был загружен. Только у `bem-components 6.0.0` таких 66 leaf-страниц (one per `{platform, block}` pair) где `readme.md` не сгенерирован. На сайте они — пустые скелеты. Я индексировал их по title-only, потому что для навигационных landing-pages это имело смысл.

## Fix

Индексируем только страницы, у которых **есть что показать**:
- любая со `contentFile` (markdown был загружен)
- `type === 'promo'` (landing-страница секции, рендерится из custom-блока)

Всё остальное отбрасывается **до** prior dedup-шага по версиям и платформам.

## Side effects

- «modal × 3» / «i-bem-dom × 3» по платформам схлопываются: живые остаются, all-empty группы пропадают целиком.
- Фильтр TOC «Статьи» из предыдущего PR теперь избыточен, но я оставляю его — defense in depth, копейки.
- Индекс ужимается ещё: локально без TOKEN 317 → ~50 docs. На CI с TOKEN, где gorshochek подтягивает больше source'ов, ожидается ~180–200 docs и gzip примерно ~150 KB на язык (было 207 KB en / 263 KB ru).

## About `mod` ↔ «модификатор»

Это не починится без cross-language stemming — русский snowball не сводит «модификатор» к латинскому stem'у, а латинский query не пересекается с кириллической формой. После фильтра пустых страниц, latin-запрос «mod» просто разрешается в реальные latin-named блоки, без empty-шума.

🤖 Generated with [Claude Code](https://claude.com/claude-code)