### PR TITLE
fix(libraries): restore bem-lib-site-view dep — lib pages were rendering blank

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "autoprefixer": "^10.4.0",
     "bem-components": "^6.0.1",
     "bem-core": "github:bem/bem-core#v5",
+    "bem-lib-site-view": "bem-site/bem-lib-site-view",
     "bem-naming": "^1.0.1",
     "bem-stat-counters": "^3.0.0",
     "bem-xjst": "^8.10.0",

--- a/scripts/bem-build.mjs
+++ b/scripts/bem-build.mjs
@@ -36,7 +36,7 @@ const BUNDLE_LEVELS = {
     'toolbox-index':              ['blocks/common', 'blocks/promo', 'blocks/toolbox', 'blocks/toolbox-index'],
     'toolbox':                    ['blocks/common', 'blocks/toolbox'],
     'libraries-index':            ['blocks/common', 'blocks/promo', 'blocks/libraries', 'blocks/libraries-index'],
-    'libraries':                  ['blocks/common', 'bundles/libraries/blocks', 'blocks/libraries'],
+    'libraries':                  ['node_modules/bem-lib-site-view/lib-view.blocks', 'blocks/common', 'bundles/libraries/blocks', 'blocks/libraries'],
     'tutorials-index':            ['blocks/common', 'blocks/promo', 'blocks/tutorials', 'blocks/tutorials-index'],
     'tutorials':                  ['blocks/common', 'blocks/tutorials'],
     'community-index':            ['blocks/common', 'blocks/promo', 'blocks/community', 'blocks/community-index'],


### PR DESCRIPTION
## Symptom

После commit \`b21e9a7e\` («Remove bem-lib-site-view dependency») каждая библиотечная страница (\`/libraries/classic/.../{platform}/{block}/\`) на проде рендерится как пустой скелет — например https://bem.info/ru/libraries/classic/bem-components/6.0.0/desktop/modal/.

Поиск (после #386) научился находить эти страницы, и пользователь начал кликать в пустоту.

## Cause

Шаблоны рендера \`block-info\`, \`block-doc\`, \`block-jsdoc\`, \`block-tabs\`, \`block-list\` живут в \`lib-view.blocks/\` пакета \`bem-lib-site-view\`. Удалив dep, мы убрали и путь к уровню в \`scripts/bem-build.mjs\` (\`'node_modules/bem-lib-site-view/lib-view.blocks'\`). Data-prep половину (\`lib/prepare-library-data.cjs\` + \`lib/library-config.cjs\`) перенесли in-tree, **rendering** половину — нет. Поэтому BEMTREE для библиотечных pages не знает, как разворачивать \`{ block: 'block-info', data: page.block }\`, и в HTML остаётся \`<div class=\"block-info\"></div>\` без содержимого.

## Fix

Минимальный revert: вернуть \`bem-lib-site-view\` в \`devDependencies\` и путь в \`scripts/bem-build.mjs\`. Data-prep остаётся in-tree, rendering приходит из dep'а — гибридный подход без изменений в логике.

Companion fix в самом пакете: [bem-site/bem-lib-site-view#32](https://github.com/bem-site/bem-lib-site-view/pull/32) — `package.json#files` содержал \`\"*.blocks\"\` (без \`/**\`), npm не упаковывал \`lib-view.blocks/\` и \`common.blocks/\`. Уже смержен.

Репозиторий \`bem-site/bem-lib-site-view\` также разархивирован — он живой и нужен.

## Verification

Локальный полный build с restored dep:

\`\`\`
/libraries/classic/bem-components/6.0.0/desktop/modal/index.html — 70 KB
  ✓ <h1>modal</h1>
  ✓ <p>Используется для создания модального окна.</p>
  ✓ <h2>Обзор блока</h2>
  ✓ <h3>Модификаторы блока</h3>  +  таблица
  ✓ block-tabs (Documentation / JSDoc / Examples / Source)
  ✓ block-list (нав по всем blocks в desktop / touch-pad / touch-phone)
\`\`\`

Поисковая выдача после deploy будет ссылаться на не-пустые страницы.

🤖 Generated with [Claude Code](https://claude.com/claude-code)