### PR TITLE
search: index key landing pages by keyword + boost keywords field

### DIFF
--- a/blocks/common/search/search.js
+++ b/blocks/common/search/search.js
@@ -248,7 +248,9 @@ export default bemDom.declBlock('search', {
         const result = await search(db, {
             term,
             properties: ['title', 'subtitle', 'keywords', 'breadcrumbs', 'body'],
-            boost: { title: 4, keywords: 4, subtitle: 2, breadcrumbs: 1, body: 1 },
+            // Curated keywords are hand-tagged to a single page and weigh
+            // more than the title — they're the intent we're encoding.
+            boost: { keywords: 8, title: 4, subtitle: 2, breadcrumbs: 1, body: 1 },
             limit: RESULT_LIMIT,
             tolerance: 1
         });

--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -57,6 +57,8 @@ export const SEARCH_SCHEMA = {
 // page wins the ranking for short / cross-language queries
 // ("mod" → /methodology/block-modification/, etc.).
 const PAGE_KEYWORDS = {
+    // Methodology (article pages — usually have content already, but the
+    // keywords act as a precise cross-language anchor for query → page)
     '/methodology/':                     ['methodology', 'методология'],
     '/methodology/quick-start/':         ['quick start', 'quickstart', 'tutorial', 'быстрый старт'],
     '/methodology/key-concepts/':        ['block', 'element', 'modifier', 'mix', 'concepts',
@@ -76,11 +78,60 @@ const PAGE_KEYWORDS = {
     '/methodology/history/':             ['history', 'origin', 'история'],
     '/methodology/faq/':                 ['faq', 'questions', 'вопросы'],
     '/methodology/articles/':            ['articles', 'статьи'],
+
+    // Section landings
     '/technologies/':                    ['technologies', 'tech', 'stack', 'технологии'],
     '/libraries/':                       ['libraries', 'library', 'lib', 'библиотеки'],
     '/toolbox/':                         ['toolbox', 'tools', 'tool', 'инструменты'],
     '/tutorials/':                       ['tutorials', 'tutorial', 'руководства'],
-    '/community/':                       ['community', 'сообщество']
+    '/community/':                       ['community', 'сообщество'],
+
+    // Technologies — these are key navigation pages without their own
+    // content; without explicit keywords they would be invisible to search.
+    //
+    // IMPORTANT: avoid keywords that contain a bare "bem" token after
+    // tokenisation (e.g. "bem-xjst" splits into ["bem", "xjst"]) — the
+    // tokeniser sees them as two separate tokens and the bare "bem" then
+    // matches every "i-bem"/"bem-foo" query, polluting other pages.
+    // Keep only the distinguishing suffix instead.
+    '/technologies/classic/':            ['classic', 'classical stack', 'классический стек'],
+    '/technologies/classic/bemjson/':    ['bemjson', 'данные', 'data'],
+    '/technologies/classic/bem-xjst/':   ['xjst', 'bemhtml', 'bemtree', 'templates', 'шаблоны'],
+    '/technologies/classic/i-bem/':      ['i-bem', 'i-bem.js', 'ibem',
+                                          'client javascript',
+                                          'клиентский javascript', 'клиентский js'],
+    '/technologies/classic/deps/':       ['deps', 'dependencies', 'зависимости'],
+    '/technologies/classic/deps-spec/':  ['deps spec', 'deps specification', 'спецификация deps'],
+    '/technologies/classic/project-stub/': ['project stub', 'project starter', 'заготовка проекта'],
+    '/technologies/bem-react/':          ['react', 'реакт'],
+    '/technologies/bem-react/motivation/': ['motivation', 'why react', 'мотивация'],
+    '/technologies/bem-react/classname/': ['classname', 'class name'],
+    '/technologies/bem-react/core/':     ['react core'],
+    '/technologies/bem-react/di/':       ['di', 'dependency injection', 'внедрение зависимостей'],
+
+    // Toolbox tools — short titles ("ENB", "bemhint", "SDK") need keyword
+    // hints so cross-language and longform queries find them.
+    '/toolbox/enb/':                     ['enb', 'build tool', 'сборщик'],
+    '/toolbox/bemhint/':                 ['bemhint', 'lint', 'linter', 'линтер'],
+    '/toolbox/bem-tools/':               ['cli', 'tools'],
+    '/toolbox/bemmet/':                  ['bemmet', 'emmet', 'shorthand'],
+    '/toolbox/sdk/':                     ['sdk', 'developer kit'],
+
+    // Library landings (without version) — top-level entry to each lib's
+    // history of versions.
+    '/libraries/classic/':               ['classic libraries', 'классические библиотеки'],
+    '/libraries/classic/bem-core/':      ['core'],
+    '/libraries/classic/bem-components/': ['components', 'компоненты'],
+    '/libraries/classic/bem-history/':   ['router', 'history'],
+    '/libraries/classic/principles/':    ['principles', 'принципы'],
+
+    // Tutorials section landings
+    '/tutorials/classic/':               ['classic tutorials', 'классические туториалы'],
+    '/tutorials/classic/quick-start-static/': ['static page tutorial', 'статическая страница'],
+    '/tutorials/classic/start-with-project-stub/': ['project stub tutorial', 'статический проект'],
+    '/tutorials/classic/start-with-bem-express/': ['bem express', 'dynamic project', 'динамический проект'],
+    '/tutorials/classic/i-bem/':         ['i-bem.js tutorial', 'руководство i-bem.js'],
+    '/tutorials/classic/dist-quick-start/': ['dist', 'bem-components dist', 'подключаем блоки']
 };
 
 function pageKeywords(url) {
@@ -128,9 +179,13 @@ function isIndexable(page) {
     //    HTML straight into the model, bypassing gorshochek md→html —
     //    every bem-components / bem-core block gets indexed this way)
     //  - promo landing pages (rendered from a custom cross-roads block)
+    //  - explicitly curated in PAGE_KEYWORDS (key navigation pages
+    //    like /technologies/classic/i-bem/ have no content of their
+    //    own but are the right destination for short queries)
     if (page.contentFile) return true;
     if (hasBlockContent(page)) return true;
     if (page.type === 'promo') return true;
+    if (PAGE_KEYWORDS[page.url]) return true;
     return false;
 }
 


### PR DESCRIPTION
## Issues найденные на проде

* \`i-bem\` показывало \`bemmet\` и случайные страницы в топе — \`/technologies/classic/i-bem/\` не имеет contentFile, block.content или promo-типа, и моя \`isIndexable()\` её фильтровала. Страница вообще не попадала в индекс.
* То же касается множества ключевых navigation landing'ов: \`/toolbox/enb/\`, \`/toolbox/bemhint/\`, \`/technologies/classic/bem-xjst/\`, \`/technologies/bem-react/\`, \`/libraries/classic/bem-core/\` и т. д. — все с генерируемой навигацией без своего markdown'а, но это правильный destination для коротких запросов.

## Что меняется

* Расширил \`PAGE_KEYWORDS\` (~25 entries) для всех ключевых navigation'ов: technologies/classic/*, technologies/bem-react/*, toolbox/*, libraries-landings, tutorials.
* Наличие в \`PAGE_KEYWORDS\` теперь достаточное основание для inclusion в индекс: \`if (PAGE_KEYWORDS[page.url]) return true;\` в \`isIndexable()\`.
* Прибавил boost у поля \`keywords\` с 4 до 8 — curated keywords привязаны к одной странице и должны весить больше, чем title.

## Tokenisation gotcha

Keyword типа \`bem-xjst\` токенизируется в \`["bem", "xjst"]\`. Голый \`bem\` затем prefix-matches каждый запрос \`i-bem\` / \`bem-foo\`, отравляя ранжирование. Я **снял префикс \`bem-\`** у всех keywords, где он не нужен для disambiguation:

- \`/technologies/classic/bem-xjst/\` → \`xjst\`
- \`/libraries/classic/bem-core/\` → \`core\`
- \`/technologies/bem-react/\` → \`react\`
- и т. д.

Сама \`/technologies/classic/i-bem/\` оставляет \`i-bem\` как identifying token.

## Smoke на индексе

\`\`\`
[ru] mod        → Модификация блока             ✅
[ru] modal      → modal × 3 platforms           ✅
[ru] именами    → Соглашение по именованию      ✅
[ru] react      → bem-react landings (top 3)    ✅
[ru] bemhtml    → Шаблоны (BEMHTML, BEMTREE)    ✅
[ru] enb        → ENB                           (new)
[ru] ibem       → /technologies/classic/i-bem/  (was missing)
[ru] i-bem      → top 3 includes /…/i-bem/      (was: bemmet)
[en] modifier   → Block modification            ✅
\`\`\`

Размер индекса ~тот же (~225 KB gzip ru) — 30 дополнительных записей дёшевы.

🤖 Generated with [Claude Code](https://claude.com/claude-code)