### PR TITLE
search: rerank by literal substring of title/keywords

### DIFF
--- a/blocks/common/search/search.js
+++ b/blocks/common/search/search.js
@@ -6,6 +6,11 @@ const MIN_QUERY = 2;
 const DEBOUNCE_MS = 100;
 const RESULT_LIMIT = 8;
 
+// Pull more candidates than we display so the post-Orama rerank can
+// promote pages whose title/keyword contains the literal query string
+// even when Orama's prefix matching scored them lower.
+const RERANK_POOL = 50;
+
 const SEARCH_SCHEMA = {
     url: 'string',
     title: 'string',
@@ -74,6 +79,30 @@ function getDb() {
         });
     }
     return dbPromise;
+}
+
+// Boost results whose title or keyword contains the query as a literal
+// substring. Orama tokenises "i-bem" into ["i", "bem"]; the bare "bem"
+// token then prefix-matches every "bem*" word in the index ("bemmet",
+// "bemhint", "bemhtml", …) and drowns the page that actually has
+// "i-bem" in its name. Re-ranking by raw substring presence rescues
+// the obvious answers without losing the long tail Orama still gives us.
+function rerankBySubstring(hits, term) {
+    const needle = String(term || '').toLowerCase().trim();
+    if (!needle) return hits;
+    return hits
+        .map(h => {
+            const doc = h.document;
+            const title = (doc.title || '').toLowerCase();
+            const kws = (doc.keywords || []).map(k => (k || '').toLowerCase());
+            let bonus = 0;
+            if (title === needle) bonus += 100;
+            if (title.includes(needle)) bonus += 50;
+            if (kws.includes(needle)) bonus += 80;
+            else if (kws.some(k => k.includes(needle))) bonus += 50;
+            return bonus ? { ...h, score: h.score + bonus } : h;
+        })
+        .sort((a, b) => b.score - a.score);
 }
 
 function escapeHtml(str) {
@@ -251,12 +280,13 @@ export default bemDom.declBlock('search', {
             // Curated keywords are hand-tagged to a single page and weigh
             // more than the title — they're the intent we're encoding.
             boost: { keywords: 8, title: 4, subtitle: 2, breadcrumbs: 1, body: 1 },
-            limit: RESULT_LIMIT,
+            limit: RERANK_POOL,
             tolerance: 1
         });
 
         this.delMod('loading');
-        this._renderHits(result.hits || [], buildHighlighter(term));
+        const hits = rerankBySubstring(result.hits || [], term).slice(0, RESULT_LIMIT);
+        this._renderHits(hits, buildHighlighter(term));
     },
 
     _renderState: function(state) {


### PR DESCRIPTION
## Symptom

Запрос \`i-bem\` поднимает в топ \`bemmet\` / \`di\` / «Шаблоны (BEMHTML, BEMTREE)», а страница «Клиентский JavaScript (i-bem.js)» — у которой это фраза стоит прямо в названии — оказывается на 5-м месте. То же для \`i-bem-dom\`, \`history\` и других составных-через-дефис запросов.

## Why

Orama токенизирует \`i-bem\` в \`["i", "bem"]\`. Когда \`bem\` становится отдельным токеном, Orama-prefix-matching ловит **каждое** \`bem*\`-слово в индексе — \`bemmet\`, \`bemhint\`, \`bemhtml\`, \`bemtree\` — и BM25-скор этих страниц перебивает релевантную.

Проверял boosts до ×32 — не помогает (prefix-spread слишком плотный).
\`exact: true\` — рушит другие запросы (\`mod\` теперь не находит \`modifier\`).
\`tolerance: 0\` — то же.
Stop-word \`bem\` — рушит \`bemhtml\` / \`bem-react\` / прямой запрос \`bem\`.

## Pragmatic fix

Запрашиваем у Orama расширенный пул кандидатов (50 вместо 8), затем на клиенте поверх BM25-скора прибавляем бонус хитам, у которых **title или keyword содержит литеральную query-строку**. Достаточно сильно чтобы поднять «правильную» страницу выше prefix-matched соседей, достаточно мягко чтобы не ломать BM25-порядок когда literal-match'а нет.

\`\`\`
+100  title === query
+80   keyword === query
+50   title or keyword contains query
\`\`\`

## Verified против живого prod-индекса (302 документа)

\`\`\`
"i-bem"      → /technologies/classic/i-bem/ + library i-bem blocks
"i-bem-dom"  → /libraries/.../{platform}/i-bem-dom/ — три платформы
"history"    → /libraries/classic/bem-history/ + history blocks
"modal"      → /libraries/.../modal/ — три платформы (как раньше)
"modifier"   → Соглашение / Модификация блока / Основные понятия
"naming" / "именами" → Соглашение по именованию (как раньше)
"javascript" → /methodology/js/ → Клиентский JavaScript (i-bem.js)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)