### PR TITLE
search: URL-pattern rank as authority signal added to BM25

### DIFF
--- a/blocks/common/search/search.js
+++ b/blocks/common/search/search.js
@@ -12,7 +12,8 @@ const SEARCH_SCHEMA = {
     subtitle: 'string',
     breadcrumbs: 'string[]',
     keywords: 'string[]',
-    body: 'string'
+    body: 'string',
+    rank: 'number'
 };
 
 let dbPromise = null;
@@ -290,12 +291,21 @@ export default bemDom.declBlock('search', {
             // Curated keywords are hand-tagged to a single page and weigh
             // more than the title — they're the intent we're encoding.
             boost: { keywords: 8, title: 4, subtitle: 2, breadcrumbs: 1, body: 1 },
-            limit: RESULT_LIMIT,
+            // Pull more candidates than we display so the post-Orama
+            // rerank by `doc.rank` (URL-pattern authority signal baked in
+            // at build time — see RANK_RULES in build-search-index.mjs)
+            // can promote authoritative pages even when their BM25 score
+            // is a few points below a verbose library stub.
+            limit: RESULT_LIMIT * 4,
             tolerance: 1
         });
 
         this.delMod('loading');
-        this._renderHits(result.hits || [], buildHighlighter(term));
+        const hits = (result.hits || [])
+            .map(h => ({ ...h, score: h.score + (h.document.rank || 0) }))
+            .sort((a, b) => b.score - a.score)
+            .slice(0, RESULT_LIMIT);
+        this._renderHits(hits, buildHighlighter(term));
     },
 
     _renderState: function(state) {

--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -103,8 +103,47 @@ export const SEARCH_SCHEMA = {
     subtitle: 'string',
     breadcrumbs: 'string[]',
     keywords: 'string[]',
-    body: 'string'
+    body: 'string',
+    // Static authority signal computed from the URL pattern at build time
+    // (see RANK_RULES). Added to the BM25 score on the client before
+    // sorting hits — enough to break ties between authoritative articles
+    // and version-specific library stubs without overpowering strong
+    // term matches.
+    rank: 'number'
 };
+
+// Authority shift applied per-URL. Typical BM25 scores fall in 5–50;
+// ±10 is meaningful but doesn't override a strong term match.
+//
+// Order matters: first match wins. Most specific patterns first.
+const RANK_RULES = [
+    // Library version-specific block stubs — short reference cards that
+    // forward the reader to the canonical doc on /technologies/.../
+    [/^\/libraries\/classic\/[^/]+\/[^/]+\/[^/]+\/[^/]+\/$/, -10],
+
+    // Library service pages (changelog, migration) — useful but rarely
+    // the first thing a search query is after.
+    [/^\/libraries\/classic\/[^/]+\/[^/]+\/(changelog|migration)\//, -5],
+
+    // Methodology — the canonical body of BEM documentation. Top-level
+    // article pages get the strongest promotion; sub-pages still
+    // promoted but less.
+    [/^\/methodology\/[^/]+\/$/, 10],
+    [/^\/methodology\//, 5],
+
+    // Section landings: technologies / toolbox top-level docs.
+    [/^\/technologies\/classic\/[^/]+\/$/, 5],
+    [/^\/technologies\/bem-react\/$/, 5],
+    [/^\/toolbox\/[^/]+\/$/, 5],
+
+    // Practical guides — useful but task-specific, mid-tier promote.
+    [/^\/tutorials\/classic\//, 3]
+];
+
+function computeRank(url) {
+    for (const [re, r] of RANK_RULES) if (re.test(url)) return r;
+    return 0;
+}
 
 // Hand-curated cross-language glossary so users can find pages by the
 // abbreviation or by the term in the other language. Each entry is a
@@ -356,8 +395,9 @@ function buildRecord(page, lang, stats, cacheDir) {
         : [];
 
     const keywords = pageKeywords(page.url);
+    const rank = computeRank(page.url);
 
-    return { id: url, url, title, subtitle, breadcrumbs, keywords, body };
+    return { id: url, url, title, subtitle, breadcrumbs, keywords, body, rank };
 }
 
 export async function buildSearchIndex({ lang, cacheDir, outputDir }) {


### PR DESCRIPTION
## What

Static `rank` field, посчитанный из URL-паттерна на этапе индексации, добавляется к BM25-скору на клиенте перед сортировкой. Логика — в одном месте (`scripts/build-search-index.mjs`), клиент просто складывает `score + doc.rank`.

## Правила

| Pattern | Rank | Comment |
|---|---|---|
| `/methodology/<page>/` | +10 | canonical БЭМ-articles |
| `/methodology/<page>/<sub>/` | +5 | sub-articles |
| `/technologies/classic/<topic>/` | +5 | section landings |
| `/technologies/bem-react/` | +5 | |
| `/toolbox/<tool>/` | +5 | |
| `/tutorials/classic/` | +3 | practical guides |
| _default_ | 0 | |
| `/libraries/…/<ver>/(changelog\|migration)/` | -5 | service pages |
| `/libraries/…/<lib>/<ver>/<platform>/<block>/` | -10 | version-block stubs |

## Why ±10

Типичные BM25 scores у нас 5–50; ±10 — заметный сдвиг на близких scores, но сильный term-match всё равно побеждает.

## Verified

```
i-bem               → Клиентский JavaScript (i-bem.js)   (было: library × 3 в топе)
элементы элементов  → Основные понятия                    (было: не в top-N)
modifier            → Соглашение / Модификация блока      (без изменений)
modal               → modal × 3                           (нет конкурента — сохранено)
i-bem-dom           → libraries i-bem-dom × 3             (нет конкурента — сохранено)
history             → bem-history landing                 (rank=0 base, сохранено)
bem-react           → bem-react landing                   (rank=5)
```

Размер индекса +1 KB на язык — ничтожно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)