### PR TITLE
search: index headings as a separate field with boost 6

### DIFF
--- a/blocks/common/search/search.js
+++ b/blocks/common/search/search.js
@@ -12,6 +12,7 @@ const SEARCH_SCHEMA = {
     subtitle: 'string',
     breadcrumbs: 'string[]',
     keywords: 'string[]',
+    headings: 'string[]',
     body: 'string',
     rank: 'number'
 };
@@ -287,10 +288,12 @@ export default bemDom.declBlock('search', {
 
         const result = await search(db, {
             term,
-            properties: ['title', 'subtitle', 'keywords', 'breadcrumbs', 'body'],
+            properties: ['title', 'subtitle', 'keywords', 'breadcrumbs', 'headings', 'body'],
             // Curated keywords are hand-tagged to a single page and weigh
-            // more than the title — they're the intent we're encoding.
-            boost: { keywords: 8, title: 4, subtitle: 2, breadcrumbs: 1, body: 1 },
+            // most. Headings name a section of the doc and are far more
+            // likely to match a user's query than a random body sentence,
+            // so they outweigh title fragments and body text.
+            boost: { keywords: 8, headings: 6, title: 4, subtitle: 2, breadcrumbs: 1, body: 1 },
             // Pull more candidates than we display so the post-Orama
             // rerank by `doc.rank` (URL-pattern authority signal baked in
             // at build time — see RANK_RULES in build-search-index.mjs)

--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -103,6 +103,7 @@ export const SEARCH_SCHEMA = {
     subtitle: 'string',
     breadcrumbs: 'string[]',
     keywords: 'string[]',
+    headings: 'string[]',
     body: 'string',
     // Static authority signal computed from the URL pattern at build time
     // (see RANK_RULES). Added to the BM25 score on the client before
@@ -255,6 +256,32 @@ function stripHtml(html) {
         .trim();
 }
 
+// Pull h1..h4 inner text into a separate searchable field. Headings name
+// the section a paragraph belongs to and a query is far more likely to
+// match the section title than a random sentence inside the section, so
+// they deserve a heavier boost than body. They are not capped — there
+// are rarely more than a few dozen per page and each is short.
+function extractHeadings(html) {
+    if (!html) return [];
+    const out = [];
+    const re = /<h[1-4]\b[^>]*>([\s\S]*?)<\/h[1-4]>/gi;
+    let m;
+    while ((m = re.exec(html)) !== null) {
+        const text = m[1]
+            .replace(/<[^>]+>/g, ' ')
+            .replace(/&nbsp;/g, ' ')
+            .replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"')
+            .replace(/&#39;/g, "'")
+            .replace(/\s+/g, ' ')
+            .trim();
+        if (text) out.push(text);
+    }
+    return out;
+}
+
 function hasBlockContent(page) {
     const c = page.block?.content;
     return Boolean(c && (c.ru || c.en || c.uk));
@@ -353,6 +380,8 @@ function buildRecord(page, lang, stats, cacheDir) {
     }
 
     let body = '';
+    let headings = [];
+    let rawHtml = '';
     if (page.contentFile) {
         // gorshochek's contentFile is always inside its cache folder; the
         // value is a leading-slash relative path like "/foo/bar/index.html".
@@ -363,7 +392,7 @@ function buildRecord(page, lang, stats, cacheDir) {
         // or .bemjson.js (when the transform pipeline didn't reach html).
         if (abs.endsWith('.html')) {
             try {
-                body = stripHtml(fs.readFileSync(abs, 'utf8'));
+                rawHtml = fs.readFileSync(abs, 'utf8');
             } catch {
                 stats.unreadable++;
             }
@@ -375,13 +404,17 @@ function buildRecord(page, lang, stats, cacheDir) {
         // pre-rendered HTML straight into the model under block.content.
         const inline = pickLang(page.block?.content, lang);
         if (inline) {
-            body = stripHtml(inline);
+            rawHtml = inline;
             stats.fromBlockContent++;
         } else {
             stats.noContentFile++;
         }
     }
-    if (body.length > BODY_MAX_CHARS) body = body.slice(0, BODY_MAX_CHARS);
+    if (rawHtml) {
+        headings = extractHeadings(rawHtml);
+        body = stripHtml(rawHtml);
+        if (body.length > BODY_MAX_CHARS) body = body.slice(0, BODY_MAX_CHARS);
+    }
 
     const url = langUrl(page.url, lang);
 
@@ -397,7 +430,7 @@ function buildRecord(page, lang, stats, cacheDir) {
     const keywords = pageKeywords(page.url);
     const rank = computeRank(page.url);
 
-    return { id: url, url, title, subtitle, breadcrumbs, keywords, body, rank };
+    return { id: url, url, title, subtitle, breadcrumbs, keywords, headings, body, rank };
 }
 
 export async function buildSearchIndex({ lang, cacheDir, outputDir }) {


### PR DESCRIPTION
## What

FAQ-страница содержит заголовок «Почему не стоит создавать элементы элементов: block__elem1__elem2», но запрос `элементы элементов` ранжировал её сильно ниже страниц где это слово встречалось только в body. Причина: body — это plain stripped HTML, заголовки лежат там вперемешку с параграфами с одинаковым весом, BM25 не различает.

Извлекаю `h1..h4` inner text в отдельное searchable поле `headings: 'string[]'` на этапе индексации, **до** strip'а HTML. Search включает его с `boost: 6` — между title (4) и curated keywords (8). Запрос, попавший в section-title, теперь скорится заметно выше, чем запрос только в прозе.

## Verified

```
элементы элементов     → Основные понятия (#1) / FAQ (#6)        ← FAQ было не в top-N
взаимодействие блоков  → Dist (#1) / Модификация блока / FAQ
состояния блока        → Dist / Модификация блока / FAQ
именами                → Соглашение по именованию / FAQ (#2)
```

## Размер

195 KB → 215 KB gzip (en), 233 KB → 258 KB gzip (ru) — +20–25 KB gzip за счёт нового поля. Заметно лучший recall на heading-anchored запросах того стоит.

🤖 Generated with [Claude Code](https://claude.com/claude-code)