### PR TITLE
search: phrase bigrams for headings + retune headings boost to 4

### DIFF
--- a/blocks/common/search/search.js
+++ b/blocks/common/search/search.js
@@ -71,11 +71,21 @@ function buildTokenizer(lang, stemmer, stopWords) {
             const n = this.normalizeToken(prop || '', input, withCache);
             return n ? [n] : [];
         }
-        const tokens = input.toLowerCase()
+        const words = input.toLowerCase()
             .split(COMPOUND_SPLITTER)
             .map(t => t.replace(TRIM_PUNCT, ''))
             .map(t => this.normalizeToken(prop || '', t, withCache))
             .filter(Boolean);
+
+        // Phrase bigrams for `headings` (where the inverted-index entry
+        // exists) and for query strings (prop undefined). Multi-word
+        // queries gain a strong signal when the same phrase appears in
+        // a section heading, without inflating the body inverted index.
+        const wantBigrams = !prop || prop === 'headings';
+        const tokens = wantBigrams && words.length > 1
+            ? words.concat(words.slice(0, -1).map((w, i) => `${w}_${words[i + 1]}`))
+            : words;
+
         return this.allowDuplicates ? tokens : Array.from(new Set(tokens));
     }.bind(tk);
     return tk;
@@ -293,7 +303,12 @@ export default bemDom.declBlock('search', {
             // most. Headings name a section of the doc and are far more
             // likely to match a user's query than a random body sentence,
             // so they outweigh title fragments and body text.
-            boost: { keywords: 8, headings: 6, title: 4, subtitle: 2, breadcrumbs: 1, body: 1 },
+            // Headings get the same boost as title — single-word headings
+            // (e.g. block-block-name as h1 of every library page) shouldn't
+            // outweigh canonical landings, but bigram tokens from multi-word
+            // headings still give a strong phrase signal when the query is
+            // a phrase too.
+            boost: { keywords: 8, title: 4, headings: 4, subtitle: 2, breadcrumbs: 1, body: 1 },
             // Pull more candidates than we display so the post-Orama
             // rerank by `doc.rank` (URL-pattern authority signal baked in
             // at build time — see RANK_RULES in build-search-index.mjs)

--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -74,11 +74,24 @@ export function buildTokenizer({ lang }) {
             const n = this.normalizeToken(prop ?? '', input, withCache);
             return n ? [n] : [];
         }
-        const tokens = input.toLowerCase()
+        const words = input.toLowerCase()
             .split(COMPOUND_SPLITTER)
             .map(t => t.replace(TRIM_PUNCT, ''))
             .map(t => this.normalizeToken(prop ?? '', t, withCache))
             .filter(Boolean);
+
+        // Bigram tokens turn "элементы элементов" / "block modification" /
+        // "файловая структура" into single inverted-index entries when
+        // the user actually queried the phrase. Applied to `headings`
+        // (the property where they matter most) and to anything tokenised
+        // outside of a specific property — i.e. query strings: Orama
+        // tokenises the query without `prop`, so query-side bigrams will
+        // align with heading-side ones.
+        const wantBigrams = !prop || prop === 'headings';
+        const tokens = wantBigrams && words.length > 1
+            ? words.concat(words.slice(0, -1).map((w, i) => `${w}_${words[i + 1]}`))
+            : words;
+
         return this.allowDuplicates ? tokens : [...new Set(tokens)];
     }.bind(tk);
     return tk;


### PR DESCRIPTION
## Two changes working together

**1. Phrase bigrams.** Токенайзер теперь рядом с unigrams выдаёт **bigrams** — пары соседних слов, склеенные через `_` (после стема и stop-фильтра). Только для поля `headings` (на индексации) и для query (на поиске). Body/title/keywords остаются с unigrams — bigramить body раздуло бы инвертированный индекс в ~2 раза при маргинальном выигрыше. Симметрично в indexer и runtime.

Эффект: запрос типа «элементы элементов» теперь производит token `элемент_элемент`, который точечно матчит FAQ-heading «Почему не стоит создавать элементы элементов» как единое целое.

**2. `headings` boost понижен с 6 до 4** (= как у title). Headings библиотечных блоков — короткие, часто single-word ("i-bem", "i-bem-dom"), и при boost=6 они lift-или library-стабы выше canonical `/technologies/classic/i-bem/` — регрессия из [#393](https://github.com/bem-site/bem.info/pull/393). С boost=4 headings остаются сильным сигналом, но не доминируют; phrase-запросы всё равно получают усиление через новые bigram-токены.

## Verified

```
«элементы элементов»     → FAQ (#1)                              ← было: не в top-N
«взаимодействие блоков»  → Модификация блока (#1)
«состояния блока»        → Модификация блока (#1)
«файловая структура»     → Файловая структура (#1)
i-bem                    → /technologies/classic/i-bem/ (#1)     ← регрессия #393 устранена
modal / modifier / naming → как раньше
```

Размер индекса: 1730 KB raw / 271 KB gzip ru — bigrams +13 KB gzip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)